### PR TITLE
Modular Methods for GPUValidator

### DIFF
--- a/src/dsmlp/app/gpu_validator.py
+++ b/src/dsmlp/app/gpu_validator.py
@@ -17,35 +17,11 @@ from dsmlp.app.config import *
 class GPUValidator(ComponentValidator):
 
     def __init__(self, awsed: AwsedClient, kube: KubeClient, logger: Logger) -> None:
+        self.awsed = awsed
         self.kube = kube
         self.logger = logger
-        self.awsed = awsed
 
-    def validate_pod(self, request: Request):
-        """
-        Validate pods for namespaces with the 'k8s-sync' label
-        """
-
-        # Low priority pods pass through
-        priority = request.object.spec.priorityClassName
-        if priority is not None and priority == LOW_PRIORITY_CLASS:
-            return
-
-        namespace = self.kube.get_namespace(request.namespace)
-        curr_gpus = self.kube.get_gpus_in_namespace(request.namespace)
-        awsed_gpu_quota = self.awsed.get_user_gpu_quota(request.namespace)
-        """
-        Use AWSED GPU quota if it is not None and greater than 0 
-        else use namespace GPU quota if it is not None and greater than 0 
-        else use 1 as default
-        """
-    
-        gpu_quota = 1
-        if awsed_gpu_quota is not None and awsed_gpu_quota > 0:
-            gpu_quota = awsed_gpu_quota
-        elif namespace.gpu_quota is not None and namespace.gpu_quota > 0:
-            gpu_quota = namespace.gpu_quota
-            
+    def get_ultilized_gpu(self, request: Request):
         # Calculate the number of GPUs requested for kube client
         utilized_gpus = 0
         for container in request.object.spec.containers:
@@ -58,14 +34,51 @@ class GPUValidator(ComponentValidator):
                 limit = int(container.resources.limits[GPU_LABEL])
             except (KeyError, AttributeError, TypeError):
                 pass
-
+            
             utilized_gpus += max(requested, limit)
-
-        # Short circuit if no GPUs requested (permits overcap)
+        
+        # Short circuit if no GPUs requested (permits overcap) or return
         if utilized_gpus == 0:
-            return
+            raise ValueError("Error: No GPUs requested.")
+        return utilized_gpus
+    
+    def get_gpu_quota(self, awsed_quota, kube_client_quota):
+        """
+        Use AWSED GPU quota if it is not None and greater than 0 
+        else use namespace GPU quota if it is not None and greater than 0 
+        else use 1 as default
+        """
+        
+        default_gpu_quota = 1
+        if awsed_quota is not None and awsed_quota > 0:
+            default_gpu_quota = awsed_quota
+        elif kube_client_quota is not None and kube_client_quota > 0:
+            default_gpu_quota = kube_client_quota
+        return default_gpu_quota
 
+    def validate_pod(self, request: Request):
+        """
+        Validate pods for namespaces with the 'k8s-sync' label
+        """
+
+        # Low priority pods pass through
+        priority = request.object.spec.priorityClassName
+        if priority is not None and priority == LOW_PRIORITY_CLASS:
+            return
+        
+        # initialized namespace, gpu_quota from awsed, and curr_gpus
+        namespace = self.kube.get_namespace(request.namespace)
+        curr_gpus = self.kube.get_gpus_in_namespace(request.namespace)
+        awsed_gpu_quota = self.awsed.get_user_gpu_quota(request.namespace)
+        
+        # check ultilized gpu
+        utilized_gpus = self.get_ultilized_gpu(request=request)
+        
+        # request gpu_quota from method
+        gpu_quota = self.get_gpu_quota(awsed_gpu_quota, namespace.gpu_quota)
+        
         # Check if the total number of utilized GPUs exceeds the GPU quota
         if utilized_gpus + curr_gpus > gpu_quota:
             raise ValidationFailure(
-                f"GPU quota exceeded. Wanted {utilized_gpus} but with {curr_gpus} already in use, the quota of {gpu_quota} would be exceeded.")
+                f"GPU quota exceeded. Wanted {utilized_gpus} but with {curr_gpus} already in use, "
+                f"the quota of {gpu_quota} would be exceeded.")

--- a/src/dsmlp/app/types.py
+++ b/src/dsmlp/app/types.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Dict
 from dataclasses_json import dataclass_json
 from abc import ABCMeta, abstractmethod
 
+# Kubernetes API types
+
 @dataclass_json
 @dataclass
 class SecurityContext:

--- a/src/dsmlp/app/validator.py
+++ b/src/dsmlp/app/validator.py
@@ -19,7 +19,7 @@ class Validator:
     def __init__(self, awsed: AwsedClient, kube: KubeClient, logger: Logger) -> None:
         self.awsed = awsed
         self.logger = logger
-        self.component_validators = [IDValidator(awsed, logger), GPUValidator(kube, logger)]
+        self.component_validators = [IDValidator(awsed, logger), GPUValidator(awsed, kube, logger)]
 
     def validate_request(self, admission_review_json):
         self.logger.debug("request=" + json.dumps(admission_review_json, indent=2))

--- a/src/dsmlp/ext/awsed.py
+++ b/src/dsmlp/ext/awsed.py
@@ -3,12 +3,12 @@ import os
 import requests
 from dacite import from_dict
 
-from dsmlp.plugin.awsed import AwsedClient, ListTeamsResponse, TeamJson, UnsuccessfulRequest, UserResponse
+from dsmlp.plugin.awsed import AwsedClient, ListTeamsResponse, TeamJson, UnsuccessfulRequest, UserResponse, UserGpuQuotaResponse
 
 import awsed.client
 import awsed.types
 
-class ExternalAwsedClient(AwsedClient):
+class ExternalAwsedClient(AwsedClient): 
     def __init__(self):
         self.client = awsed.client.DefaultAwsedClient(endpoint=os.environ.get('AWSED_ENDPOINT'),
                                                       awsed_api_key=os.environ.get('AWSED_API_KEY'))
@@ -27,3 +27,13 @@ class ExternalAwsedClient(AwsedClient):
             teams.append(TeamJson(gid=team.gid))
             
         return ListTeamsResponse(teams=teams)
+    
+    # Fetch user's GPU quota with AWSED Api and assign to UserGpuQuotaResponse object
+    def get_user_gpu_quota(self, username: str) -> UserGpuQuotaResponse:
+        try:
+            usrGpuQuota = self.client.fetch_user_gpu_quota(username)
+            if not usrGpuQuota:
+                return None
+            return UserGpuQuotaResponse(gpu_quota=usrGpuQuota.gpuQuota)
+        except:
+            return None

--- a/src/dsmlp/plugin/awsed.py
+++ b/src/dsmlp/plugin/awsed.py
@@ -18,17 +18,24 @@ class UserResponse:
     uid: int
     enrollments: List[str]
 
+@dataclass
+class UserGpuQuotaResponse:
+    gpu_quota: int
 
 class AwsedClient(metaclass=ABCMeta):
     @abstractmethod
     def list_user_teams(self, username: str) -> ListTeamsResponse:
-        """Return the groups of a course"""
+        # Return the groups of a course
         pass
 
     @abstractmethod
     def describe_user(self, username: str) -> UserResponse:
         pass
-
+    
+    @abstractmethod
+    def get_user_gpu_quota(self, username: str) -> UserGpuQuotaResponse:
+        # Return the gpu quota of a user
+        pass
 
 class UnsuccessfulRequest(Exception):
     pass

--- a/tests/app/test_gpu_validator.py
+++ b/tests/app/test_gpu_validator.py
@@ -136,3 +136,6 @@ class TestGPUValidator:
         self.try_validate(
             gen_request(gpu_req=6, username='user11'), expected=True, message="GPU quota exceeded. Wanted 6 but with 5 already in use, the quota of 18 would be exceeded."
         )
+        
+    # --- Modular / Unit Testing for Validate Pod ---
+    def test

--- a/tests/app/test_logs.py
+++ b/tests/app/test_logs.py
@@ -93,7 +93,31 @@ class TestLogs:
 
         assert_that(self.logger.messages, has_item(
             "INFO Allowed request username=user10 namespace=user10 uid=705ab4f5-6393-11e8-b7cc-42010a800002"))
-
+        
+    # def test_gpu_quota_request(self):
+    #     self.awsed_client.add_user_gpu_quota('user10', 10)
+    #     self.awsed_client.get_user_gpu_quota('user10')
+        
+    #     response = self.when_validate(
+    #         {
+    #             "request": {
+    #                 "uid": "705ab4f5-6393-11e8-b7cc-42010a800002",
+    #                 "namespace": "user10",
+    #                 "userInfo": {
+    #                     "username": "user10"
+    #                 },
+    #                 "object": {
+    #                     "metadata": {
+    #                         "labels": {}
+    #                     },
+    #                     "spec": {
+    #                         "containers": [{}]
+    #                     }
+    #                 }
+    #             }
+    #         }
+    #     )
+        
     def when_validate(self, json):
         validator = Validator(self.awsed_client, self.kube_client, self.logger)
         response = validator.validate_request(json)

--- a/tests/app/utils.py
+++ b/tests/app/utils.py
@@ -6,9 +6,13 @@ from typing import List
 
 
 def gen_request(gpu_req: int = 0, gpu_lim: int = 0, low_priority: bool = False, uid: str = "705ab4f5-6393-11e8-b7cc-42010a800002", course: str = None,
-                run_as_user: int = None, run_as_group: int = None, fs_group: int = None, supplemental_groups: List[int] = None, username: str = "user10", has_container: bool = True,
+                run_as_user: int = None, run_as_group: int = None, fs_group: int = None, supplemental_groups: List[int] = None, username: str = None, has_container: bool = True,
                 container_override: List[Container] = None, init_containers: List[Container] = None) -> Request:
-
+    
+    # add default username is user10 unless specified during testing
+    if username is None:
+        username = 'user10'
+        
     res_req = None
     if gpu_req > 0:
         if res_req is None:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5,7 +5,7 @@ from typing import List, TypedDict, Dict
 
 from dacite import from_dict
 
-from dsmlp.plugin.awsed import AwsedClient,  ListTeamsResponse, UnsuccessfulRequest, UserResponse
+from dsmlp.plugin.awsed import AwsedClient,  ListTeamsResponse, UnsuccessfulRequest, UserResponse, UserGpuQuotaResponse
 from dsmlp.plugin.kube import KubeClient, Namespace, NotFound
 from dsmlp.plugin.logger import Logger
 
@@ -14,6 +14,7 @@ class FakeAwsedClient(AwsedClient):
     def __init__(self):
         self.teams: Dict[str, ListTeamsResponse] = {}
         self.users: Dict[str, UserResponse] = {}
+        self.user_gpu_quota: Dict[str, UserGpuQuotaResponse] = {}
 
     def list_user_teams(self, username: str) -> ListTeamsResponse:
         try:
@@ -28,7 +29,17 @@ class FakeAwsedClient(AwsedClient):
             return self.users[username]
         except KeyError:
             return None
-
+    
+    # Get user GPU quota. If user does not exist, return 0
+    def get_user_gpu_quota(self, username: str) -> UserGpuQuotaResponse:
+        try:
+            return self.user_gpu_quota[username]
+        except KeyError:
+            return 0
+        
+    def add_user_gpu_quota(self, username, gpu_quota: UserGpuQuotaResponse):
+        self.user_gpu_quota[username] = gpu_quota
+    
     def add_user(self, username, user: UserResponse):
         self.users[username] = user
 


### PR DESCRIPTION
Add modular methods to call for validate_pod to unit test each individual components.

Current errors:
Testlogs are not accepting raised ValueError and some tests in GPUValidator are not used to a new return error